### PR TITLE
Improve flipped tile layout

### DIFF
--- a/script.js
+++ b/script.js
@@ -118,8 +118,12 @@ function showServices(category) {
     const back = document.createElement('div');
     back.className = 'tile-face tile-back';
 
+    const backBody = document.createElement('div');
+    backBody.className = 'tile-back-body';
+
     const details = document.createElement('p');
     details.textContent = service.details || '';
+    backBody.appendChild(details);
 
     const featureList = document.createElement('ul');
     (service.features || []).forEach((feature) => {
@@ -127,6 +131,7 @@ function showServices(category) {
       item.textContent = feature;
       featureList.appendChild(item);
     });
+    backBody.appendChild(featureList);
 
     const link = document.createElement('a');
     link.href = service.link || '#';
@@ -135,7 +140,7 @@ function showServices(category) {
     link.textContent = '公式サイトを見る';
     link.addEventListener('click', (event) => event.stopPropagation());
 
-    back.append(details, featureList, link);
+    back.append(backBody, link);
 
     inner.append(front, back);
     tile.appendChild(inner);

--- a/styles.css
+++ b/styles.css
@@ -165,6 +165,7 @@ body {
   padding: 0;
   height: 260px;
   perspective: 1200px;
+  overflow: hidden;
 }
 
 .service-tile .tile-inner {
@@ -191,6 +192,7 @@ body {
   border-radius: var(--border-radius);
   background: var(--card-bg);
   box-shadow: var(--shadow-sm);
+  overflow: hidden;
 }
 
 .tile-front {
@@ -212,10 +214,25 @@ body {
   font-weight: 600;
 }
 
+
 .tile-back {
   transform: rotateY(180deg);
   justify-content: flex-start;
   gap: 12px;
+  overflow: hidden;
+}
+
+.tile-back-body {
+  flex: 1 1 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  overflow-y: auto;
+  overflow-x: hidden;
+  padding-right: 6px;
+  scrollbar-gutter: stable;
+  overscroll-behavior: contain;
+  -webkit-overflow-scrolling: touch;
 }
 
 .tile-back p {


### PR DESCRIPTION
## Summary
- clamp service tiles and their faces to the card height to prevent flipped content from escaping
- move the back-face copy into a scrollable container so long descriptions remain readable

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cd1b6d13348327b36b04c0a8a733c8