### PR TITLE
Expand flipped service tiles for details

### DIFF
--- a/script.js
+++ b/script.js
@@ -159,7 +159,15 @@ function showServices(category) {
 
 function toggleServiceTile(tile) {
   const willFlip = !tile.classList.contains('flipped');
-  tile.classList.toggle('flipped');
+
+  tileContainer.querySelectorAll('.service-tile.flipped').forEach((otherTile) => {
+    if (otherTile !== tile) {
+      otherTile.classList.remove('flipped');
+      otherTile.setAttribute('aria-pressed', 'false');
+    }
+  });
+
+  tile.classList.toggle('flipped', willFlip);
   tile.setAttribute('aria-pressed', willFlip ? 'true' : 'false');
 }
 

--- a/styles.css
+++ b/styles.css
@@ -166,6 +166,18 @@ body {
   height: 260px;
   perspective: 1200px;
   overflow: hidden;
+  transition: transform var(--transition), box-shadow var(--transition), height 0.45s ease;
+}
+
+.service-tile.flipped {
+  height: clamp(320px, 40vw, 420px);
+  z-index: 2;
+}
+
+@media (min-width: 900px) {
+  .service-tile.flipped {
+    grid-column: span 2;
+  }
 }
 
 .service-tile .tile-inner {


### PR DESCRIPTION
## Summary
- expand service tiles when flipped so the back face provides more readable space for details
- span flipped tiles across two columns on wide screens and collapse other tiles when a new one opens

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68cd1d19deb48327ab15889a3ff34e85