### PR TITLE
Remove Google Cloud hero link and updates section

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,7 +21,6 @@
         強みを俯瞰できるリソースです。マルチクラウドの比較検討や学習の入口としてご活用ください。
       </p>
       <div class="hero-actions">
-        <a class="hero-button" href="google-cloud.html">Google Cloud を見る</a>
         <a class="hero-button hero-button--secondary" href="#features">使い方を確認する</a>
       </div>
       <dl class="hero-metrics">
@@ -129,23 +128,6 @@
         </ol>
       </section>
 
-      <section class="home-section" id="updates">
-        <h2 class="section-title">最新の更新情報</h2>
-        <ul class="updates-list">
-          <li>
-            <time datetime="2024-04">2024 年 4 月</time>
-            Google Cloud / Azure / AWS の主要サービスデータをアップデートしました。
-          </li>
-          <li>
-            <time datetime="2024-03">2024 年 3 月</time>
-            サービスカードの詳細表示に使いやすい UI を導入しました。
-          </li>
-          <li>
-            <time datetime="2024-02">2024 年 2 月</time>
-            マルチクラウド比較のためのカテゴリ整理を再構成しました。
-          </li>
-        </ul>
-      </section>
     </main>
 
     <footer class="page-footer home-footer">


### PR DESCRIPTION
## Summary
- remove the Google Cloud shortcut button from the home page hero actions
- delete the "最新の更新情報" section from the bottom of the home page

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cd2b2f0b8883278817714313e8087b