### PR TITLE
Remove hero metrics section from home page

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,20 +23,6 @@
       <div class="hero-actions">
         <a class="hero-button hero-button--secondary" href="#features">使い方を確認する</a>
       </div>
-      <dl class="hero-metrics">
-        <div class="hero-metric">
-          <dt>掲載サービス</dt>
-          <dd>150+ 件</dd>
-        </div>
-        <div class="hero-metric">
-          <dt>カテゴリ</dt>
-          <dd>30 分野</dd>
-        </div>
-        <div class="hero-metric">
-          <dt>データ最終更新</dt>
-          <dd>2024 年</dd>
-        </div>
-      </dl>
       <nav class="page-nav" aria-label="クラウドプロバイダー">
         <ul class="nav-list">
           <li class="nav-item">


### PR DESCRIPTION
## Summary
- remove the hero metrics items from the top page hero section

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cd2bfedd5c832788488e9425694ef4