### PR TITLE
Move onboarding steps into hero section

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,9 +20,34 @@
         Google Cloud、Microsoft Azure、Amazon Web Services を横断して、主要サービスの概要と
         強みを俯瞰できるリソースです。マルチクラウドの比較検討や学習の入口としてご活用ください。
       </p>
-      <div class="hero-actions">
-        <a class="hero-button hero-button--secondary" href="#features">使い方を確認する</a>
-      </div>
+      <section class="hero-steps" id="features" aria-labelledby="hero-steps-title">
+        <h2 class="hero-steps__title" id="hero-steps-title">
+          クラウド選定・学習をスムーズにする 3 ステップ
+        </h2>
+        <p class="hero-steps__intro">
+          カテゴリからサービスの概要・活用ポイントを素早く確認できるように設計しています。初めてクラウドを触れる方にも、比較検討中の方にもおすすめです。
+        </p>
+        <ol class="steps-list">
+          <li>
+            <h3>カテゴリから絞り込む</h3>
+            <p>
+              コンピューティング、データベース、AI などのカテゴリ単位でサービスを整理。目的に応じて関連サービスを一覧できます。
+            </p>
+          </li>
+          <li>
+            <h3>カードで概要を把握</h3>
+            <p>
+              各サービスの特徴や代表的なユースケースをカード形式で掲載。クリックすると詳細情報や活用のヒントが表示されます。
+            </p>
+          </li>
+          <li>
+            <h3>公式ドキュメントへアクセス</h3>
+            <p>
+              より詳しい情報が必要なときは公式サイトへのリンクを用意。学習や導入検討を次のステップに進められます。
+            </p>
+          </li>
+        </ol>
+      </section>
       <nav class="page-nav" aria-label="クラウドプロバイダー">
         <ul class="nav-list">
           <li class="nav-item">
@@ -85,33 +110,6 @@
             <a class="provider-card__link" href="aws.html">Amazon Web Services のマップを見る</a>
           </article>
         </div>
-      </section>
-
-      <section class="home-section" id="features">
-        <h2 class="section-title">クラウド選定・学習をスムーズにする 3 ステップ</h2>
-        <p class="section-intro">
-          カテゴリからサービスの概要・活用ポイントを素早く確認できるように設計しています。初めてクラウドを触れる方にも、比較検討中の方にもおすすめです。
-        </p>
-        <ol class="steps-list">
-          <li>
-            <h3>カテゴリから絞り込む</h3>
-            <p>
-              コンピューティング、データベース、AI などのカテゴリ単位でサービスを整理。目的に応じて関連サービスを一覧できます。
-            </p>
-          </li>
-          <li>
-            <h3>カードで概要を把握</h3>
-            <p>
-              各サービスの特徴や代表的なユースケースをカード形式で掲載。クリックすると詳細情報や活用のヒントが表示されます。
-            </p>
-          </li>
-          <li>
-            <h3>公式ドキュメントへアクセス</h3>
-            <p>
-              より詳しい情報が必要なときは公式サイトへのリンクを用意。学習や導入検討を次のステップに進められます。
-            </p>
-          </li>
-        </ol>
       </section>
 
     </main>

--- a/styles.css
+++ b/styles.css
@@ -402,6 +402,44 @@ body {
   font-size: 1.05rem;
 }
 
+.hero-steps {
+  margin: clamp(36px, 7vw, 56px) auto 0;
+  padding: clamp(28px, 6vw, 40px);
+  max-width: min(920px, 100%);
+  border-radius: 28px;
+  background: linear-gradient(
+      135deg,
+      rgba(var(--accent-rgb), 0.16),
+      rgba(var(--accent-rgb), 0.08)
+    ),
+    rgba(255, 255, 255, 0.85);
+  border: 1px solid rgba(var(--accent-rgb), 0.22);
+  box-shadow: 0 26px 52px rgba(var(--accent-rgb), 0.18);
+  display: flex;
+  flex-direction: column;
+  gap: 28px;
+  text-align: left;
+  backdrop-filter: blur(6px);
+}
+
+.hero-steps__title {
+  margin: 0;
+  font-size: clamp(1.9rem, 4vw, 2.3rem);
+  font-weight: 700;
+  letter-spacing: 0.03em;
+}
+
+.hero-steps__intro {
+  margin: 0;
+  max-width: 720px;
+  color: var(--text-muted);
+  font-size: 1rem;
+}
+
+.hero-steps .steps-list {
+  gap: clamp(20px, 5vw, 28px);
+}
+
 .hero-actions {
   margin: 36px auto 0;
   display: flex;
@@ -666,6 +704,16 @@ body {
 @media (max-width: 720px) {
   .hero-metrics {
     margin-top: 36px;
+  }
+
+  .hero-steps {
+    padding: 28px 24px;
+    border-radius: 24px;
+    gap: 24px;
+  }
+
+  .hero-steps .steps-list {
+    grid-template-columns: 1fr;
   }
 
   .hero-button {


### PR DESCRIPTION
## Summary
- replace the hero action button with the three-step onboarding guidance so it appears directly in the main hero area
- add dedicated styling for the hero steps container to keep the numbered cards readable within the header background
- remove the duplicate three-step section from the main content to avoid repetition

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68cd2cb6e10483278aee3478d99bd129