### PR TITLE
Align provider order to AWS, Azure, and Google Cloud

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,15 @@
 # cloud-map
 
-Google Cloud / Microsoft Azure / Amazon Web Services の主要サービスをカテゴリ別に整理した
+Amazon Web Services / Microsoft Azure / Google Cloud の主要サービスをカテゴリ別に整理した
 サービスマップです。各クラウドごとに専用ページを用意し、カテゴリからサービスの概要
 や代表的な特徴、公式ドキュメントへのリンクを確認できます。
 
 ## ページ構成
 
-- `index.html` : Google Cloud 版サービスマップ
-- `azure.html` : Microsoft Azure 版サービスマップ
+- `index.html` : ホーム / クラウド横断ハイライト
 - `aws.html` : Amazon Web Services 版サービスマップ
+- `azure.html` : Microsoft Azure 版サービスマップ
+- `google-cloud.html` : Google Cloud 版サービスマップ
 - `comparison.html` : 主要サービスの横断比較表
 
 ページ上部のメニューからクラウドを切り替えられます。いずれのページも同じ UI で動作し

--- a/aws.html
+++ b/aws.html
@@ -31,13 +31,13 @@
             <a class="nav-link" href="index.html">ホーム</a>
           </li>
           <li class="nav-item">
-            <a class="nav-link" href="google-cloud.html">Google Cloud</a>
+            <a class="nav-link" href="aws.html" aria-current="page">Amazon Web Services</a>
           </li>
           <li class="nav-item">
             <a class="nav-link" href="azure.html">Microsoft Azure</a>
           </li>
           <li class="nav-item">
-            <a class="nav-link" href="aws.html" aria-current="page">Amazon Web Services</a>
+            <a class="nav-link" href="google-cloud.html">Google Cloud</a>
           </li>
           <li class="nav-item">
             <a class="nav-link" href="comparison.html">サービス比較</a>

--- a/azure.html
+++ b/azure.html
@@ -31,13 +31,13 @@
             <a class="nav-link" href="index.html">ホーム</a>
           </li>
           <li class="nav-item">
-            <a class="nav-link" href="google-cloud.html">Google Cloud</a>
+            <a class="nav-link" href="aws.html">Amazon Web Services</a>
           </li>
           <li class="nav-item">
             <a class="nav-link" href="azure.html" aria-current="page">Microsoft Azure</a>
           </li>
           <li class="nav-item">
-            <a class="nav-link" href="aws.html">Amazon Web Services</a>
+            <a class="nav-link" href="google-cloud.html">Google Cloud</a>
           </li>
           <li class="nav-item">
             <a class="nav-link" href="comparison.html">サービス比較</a>

--- a/comparison.html
+++ b/comparison.html
@@ -16,7 +16,7 @@
     <header class="page-header">
       <h1 class="headline">主要クラウドサービス比較表</h1>
       <p class="tagline">
-        Google Cloud、Amazon Web Services、Microsoft Azure で提供されている代表的なサービス
+        Amazon Web Services、Microsoft Azure、Google Cloud で提供されている代表的なサービス
         の対応関係をカテゴリ別に整理しました。マルチクラウド戦略の検討や移行時の置き換え先の
         目安としてご利用ください。
       </p>
@@ -26,13 +26,13 @@
             <a class="nav-link" href="index.html">ホーム</a>
           </li>
           <li class="nav-item">
-            <a class="nav-link" href="google-cloud.html">Google Cloud</a>
+            <a class="nav-link" href="aws.html">Amazon Web Services</a>
           </li>
           <li class="nav-item">
             <a class="nav-link" href="azure.html">Microsoft Azure</a>
           </li>
           <li class="nav-item">
-            <a class="nav-link" href="aws.html">Amazon Web Services</a>
+            <a class="nav-link" href="google-cloud.html">Google Cloud</a>
           </li>
           <li class="nav-item">
             <a class="nav-link" href="comparison.html" aria-current="page">サービス比較</a>
@@ -69,23 +69,23 @@
         <div class="table-wrapper" role="region" aria-labelledby="comparison-table-title" tabindex="0">
           <table class="comparison-table">
             <caption>
-              Google Cloud、Amazon Web Services、Microsoft Azure の代表的なサービス比較表
+              Amazon Web Services、Microsoft Azure、Google Cloud の代表的なサービス比較表
             </caption>
             <thead>
               <tr>
                 <th scope="col">カテゴリ</th>
-                <th scope="col">Google Cloud</th>
                 <th scope="col">Amazon Web Services</th>
                 <th scope="col">Microsoft Azure</th>
+                <th scope="col">Google Cloud</th>
                 <th scope="col">特徴・補足</th>
               </tr>
             </thead>
             <tbody>
               <tr>
                 <th scope="row" class="category-cell">仮想マシン (IaaS)</th>
-                <td class="service-cell">Compute Engine</td>
                 <td class="service-cell">Amazon EC2</td>
                 <td class="service-cell">Azure Virtual Machines</td>
+                <td class="service-cell">Compute Engine</td>
                 <td class="note-cell">
                   汎用から GPU、SAP 認定インスタンスまで幅広いラインアップを提供。永続ディスクや
                   スナップショット、オートスケーリングの仕組みで柔軟にリソースを増減できます。
@@ -93,9 +93,9 @@
               </tr>
               <tr>
                 <th scope="row" class="category-cell">マネージド Kubernetes</th>
-                <td class="service-cell">Google Kubernetes Engine (GKE)</td>
                 <td class="service-cell">Amazon Elastic Kubernetes Service (EKS)</td>
                 <td class="service-cell">Azure Kubernetes Service (AKS)</td>
+                <td class="service-cell">Google Kubernetes Engine (GKE)</td>
                 <td class="note-cell">
                   コントロールプレーンの管理を各クラウドが担う Kubernetes サービス。オートスケール、
                   マルチゾーン構成、マネージドアドオンなどを活用することで運用負荷を抑えられます。
@@ -103,9 +103,9 @@
               </tr>
               <tr>
                 <th scope="row" class="category-cell">フルマネージド コンテナ実行</th>
-                <td class="service-cell">Cloud Run</td>
                 <td class="service-cell">AWS App Runner</td>
                 <td class="service-cell">Azure Container Apps</td>
+                <td class="service-cell">Cloud Run</td>
                 <td class="note-cell">
                   コンテナをソースコードや OCI イメージから即時にデプロイできる環境。トラフィック連
                   動のオートスケールやゼロスケール対応で、マイクロサービスや API バックエンドに最適
@@ -114,9 +114,9 @@
               </tr>
               <tr>
                 <th scope="row" class="category-cell">サーバーレス関数</th>
-                <td class="service-cell">Cloud Functions (2nd gen)</td>
                 <td class="service-cell">AWS Lambda</td>
                 <td class="service-cell">Azure Functions</td>
+                <td class="service-cell">Cloud Functions (2nd gen)</td>
                 <td class="note-cell">
                   イベント駆動の短時間処理に最適な関数サービス。トリガーの種類や最大実行時間、言語サ
                   ポートなどを比較してワークロードに適した構成を選択します。
@@ -124,9 +124,9 @@
               </tr>
               <tr>
                 <th scope="row" class="category-cell">オブジェクトストレージ</th>
-                <td class="service-cell">Cloud Storage</td>
                 <td class="service-cell">Amazon S3</td>
                 <td class="service-cell">Azure Blob Storage</td>
+                <td class="service-cell">Cloud Storage</td>
                 <td class="note-cell">
                   静的コンテンツやバックアップ、データレイク基盤に利用される耐久性の高いストレージ。
                   ストレージクラスやライフサイクルポリシーを活用してコストとパフォーマンスを最適化。
@@ -134,9 +134,9 @@
               </tr>
               <tr>
                 <th scope="row" class="category-cell">リレーショナル DB (PaaS)</th>
-                <td class="service-cell">Cloud SQL</td>
                 <td class="service-cell">Amazon RDS</td>
                 <td class="service-cell">Azure SQL Database</td>
+                <td class="service-cell">Cloud SQL</td>
                 <td class="note-cell">
                   MySQL や PostgreSQL、SQL Server などのエンジンをマネージドで提供。自動バックアップや
                   フェイルオーバー、読み取りレプリカなどの機能で運用を簡素化します。
@@ -144,9 +144,9 @@
               </tr>
               <tr>
                 <th scope="row" class="category-cell">ドキュメント / キーバリュー DB</th>
-                <td class="service-cell">Cloud Firestore</td>
                 <td class="service-cell">Amazon DynamoDB</td>
                 <td class="service-cell">Azure Cosmos DB</td>
+                <td class="service-cell">Cloud Firestore</td>
                 <td class="note-cell">
                   スキーマレスでスケーラブルなデータベース。グローバル分散やマルチマスター構成、柔軟
                   なスループット課金などを備え、低レイテンシのアプリケーションに適しています。
@@ -154,9 +154,9 @@
               </tr>
               <tr>
                 <th scope="row" class="category-cell">データウェアハウス</th>
-                <td class="service-cell">BigQuery</td>
                 <td class="service-cell">Amazon Redshift</td>
                 <td class="service-cell">Azure Synapse Analytics (Dedicated SQL Pool)</td>
+                <td class="service-cell">BigQuery</td>
                 <td class="note-cell">
                   大規模データを分析するための高速クエリエンジン。サーバーレス実行やコンピュート/ス
                   トレージ分離、各種 BI 連携でデータ利活用を加速します。
@@ -164,9 +164,9 @@
               </tr>
               <tr>
                 <th scope="row" class="category-cell">メッセージング / イベント配信</th>
-                <td class="service-cell">Pub/Sub</td>
                 <td class="service-cell">Amazon SNS</td>
                 <td class="service-cell">Azure Event Grid</td>
+                <td class="service-cell">Pub/Sub</td>
                 <td class="note-cell">
                   疎結合なイベント駆動アーキテクチャを構築するためのメッセージング基盤。Push/Pull 配
                   信やフィルタリング、他サービスとの統合のしやすさを比較することが重要です。
@@ -174,9 +174,9 @@
               </tr>
               <tr>
                 <th scope="row" class="category-cell">データ処理 / ETL</th>
-                <td class="service-cell">Dataflow</td>
                 <td class="service-cell">AWS Glue</td>
                 <td class="service-cell">Azure Data Factory</td>
+                <td class="service-cell">Dataflow</td>
                 <td class="note-cell">
                   サーバーレスでバッチ・ストリーミング処理を実現するデータ統合サービス。コネクタの種
                   類やスケーリング方式、コード/ノーコードの開発体験を比較します。
@@ -184,9 +184,9 @@
               </tr>
               <tr>
                 <th scope="row" class="category-cell">監視 / 可観測性</th>
-                <td class="service-cell">Cloud Monitoring / Logging</td>
                 <td class="service-cell">Amazon CloudWatch</td>
                 <td class="service-cell">Azure Monitor</td>
+                <td class="service-cell">Cloud Monitoring / Logging</td>
                 <td class="note-cell">
                   メトリクス、ログ、トレースを統合的に収集・可視化する監視基盤。自動アラートやダッシ
                   ュボード、外部ツールとの連携状況も選定のポイントです。
@@ -204,9 +204,9 @@
           介しています。より深く検討したい場合は以下のリンクをご活用ください。
         </p>
         <div class="comparison-links">
-          <a class="comparison-link" href="google-cloud.html">Google Cloud サービスマップ</a>
-          <a class="comparison-link" href="azure.html">Microsoft Azure サービスマップ</a>
           <a class="comparison-link" href="aws.html">Amazon Web Services サービスマップ</a>
+          <a class="comparison-link" href="azure.html">Microsoft Azure サービスマップ</a>
+          <a class="comparison-link" href="google-cloud.html">Google Cloud サービスマップ</a>
         </div>
       </section>
     </main>

--- a/google-cloud.html
+++ b/google-cloud.html
@@ -31,13 +31,13 @@
             <a class="nav-link" href="index.html">ホーム</a>
           </li>
           <li class="nav-item">
-            <a class="nav-link" href="google-cloud.html" aria-current="page">Google Cloud</a>
+            <a class="nav-link" href="aws.html">Amazon Web Services</a>
           </li>
           <li class="nav-item">
             <a class="nav-link" href="azure.html">Microsoft Azure</a>
           </li>
           <li class="nav-item">
-            <a class="nav-link" href="aws.html">Amazon Web Services</a>
+            <a class="nav-link" href="google-cloud.html" aria-current="page">Google Cloud</a>
           </li>
           <li class="nav-item">
             <a class="nav-link" href="comparison.html">サービス比較</a>

--- a/index.html
+++ b/index.html
@@ -17,7 +17,7 @@
       <p class="hero-label">CLOUD LANDSCAPE GUIDE</p>
       <h1 class="hero-title">クラウドサービス マップ</h1>
       <p class="hero-lead">
-        Google Cloud、Microsoft Azure、Amazon Web Services を横断して、主要サービスの概要と
+        Amazon Web Services、Microsoft Azure、Google Cloud を横断して、主要サービスの概要と
         強みを俯瞰できるリソースです。マルチクラウドの比較検討や学習の入口としてご活用ください。
       </p>
       <section class="hero-steps" id="features" aria-labelledby="hero-steps-title">
@@ -54,13 +54,13 @@
             <a class="nav-link" href="index.html" aria-current="page">ホーム</a>
           </li>
           <li class="nav-item">
-            <a class="nav-link" href="google-cloud.html">Google Cloud</a>
+            <a class="nav-link" href="aws.html">Amazon Web Services</a>
           </li>
           <li class="nav-item">
             <a class="nav-link" href="azure.html">Microsoft Azure</a>
           </li>
           <li class="nav-item">
-            <a class="nav-link" href="aws.html">Amazon Web Services</a>
+            <a class="nav-link" href="google-cloud.html">Google Cloud</a>
           </li>
           <li class="nav-item">
             <a class="nav-link" href="comparison.html">サービス比較</a>
@@ -76,17 +76,17 @@
           各クラウドで提供されている主要サービス領域をコンパクトに把握できます。気になるプロバイダーを選んで詳細なカテゴリやサービス情報をチェックしましょう。
         </p>
         <div class="provider-grid">
-          <article class="provider-card provider-card--gcp">
-            <h3 class="provider-card__title">Google Cloud</h3>
+          <article class="provider-card provider-card--aws">
+            <h3 class="provider-card__title">Amazon Web Services</h3>
             <p class="provider-card__description">
-              データ分析と機械学習に強みを持つ Google のクラウドプラットフォーム。スケーラブルなコンテナ基盤とグローバルなネットワークが特徴です。
+              業界最多のサービス群を備えた AWS。スタートアップからエンタープライズまで幅広いユースケースをカバーする柔軟性が魅力です。
             </p>
             <ul class="provider-card__list">
-              <li>BigQuery や Vertex AI などの分析・AI サービス</li>
-              <li>Anthos をはじめとしたマルチクラウド運用</li>
-              <li>セキュアで開発者フレンドリーな環境</li>
+              <li>コンピューティングから機械学習まで豊富な選択肢</li>
+              <li>Well-Architected Framework に基づくベストプラクティス</li>
+              <li>世界各地のリージョンでグローバル展開</li>
             </ul>
-            <a class="provider-card__link" href="google-cloud.html">Google Cloud のマップを見る</a>
+            <a class="provider-card__link" href="aws.html">Amazon Web Services のマップを見る</a>
           </article>
           <article class="provider-card provider-card--azure">
             <h3 class="provider-card__title">Microsoft Azure</h3>
@@ -100,17 +100,17 @@
             </ul>
             <a class="provider-card__link" href="azure.html">Microsoft Azure のマップを見る</a>
           </article>
-          <article class="provider-card provider-card--aws">
-            <h3 class="provider-card__title">Amazon Web Services</h3>
+          <article class="provider-card provider-card--gcp">
+            <h3 class="provider-card__title">Google Cloud</h3>
             <p class="provider-card__description">
-              業界最多のサービス群を備えた AWS。スタートアップからエンタープライズまで幅広いユースケースをカバーする柔軟性が魅力です。
+              データ分析と機械学習に強みを持つ Google のクラウドプラットフォーム。スケーラブルなコンテナ基盤とグローバルなネットワークが特徴です。
             </p>
             <ul class="provider-card__list">
-              <li>コンピューティングから機械学習まで豊富な選択肢</li>
-              <li>Well-Architected Framework に基づくベストプラクティス</li>
-              <li>世界各地のリージョンでグローバル展開</li>
+              <li>BigQuery や Vertex AI などの分析・AI サービス</li>
+              <li>Anthos をはじめとしたマルチクラウド運用</li>
+              <li>セキュアで開発者フレンドリーな環境</li>
             </ul>
-            <a class="provider-card__link" href="aws.html">Amazon Web Services のマップを見る</a>
+            <a class="provider-card__link" href="google-cloud.html">Google Cloud のマップを見る</a>
           </article>
         </div>
       </section>


### PR DESCRIPTION
## Summary
- reorder the homepage navigation, highlights, and introductory copy to follow the AWS → Azure → Google Cloud sequence.
- update provider navigation on each detail page and restructure the comparison table to match the new ordering.
- refresh the README page list so documentation reflects the AWS-first order.

## Testing
- not run (static content)


------
https://chatgpt.com/codex/tasks/task_e_68cd38d0c5208327ae107b80b8ff8a03