### PR TITLE
Link comparison table services to official sites

### DIFF
--- a/comparison.html
+++ b/comparison.html
@@ -83,9 +83,17 @@
             <tbody>
               <tr>
                 <th scope="row" class="category-cell">仮想マシン (IaaS)</th>
-                <td class="service-cell">Amazon EC2</td>
-                <td class="service-cell">Azure Virtual Machines</td>
-                <td class="service-cell">Compute Engine</td>
+                <td class="service-cell">
+                  <a href="https://aws.amazon.com/ec2/">Amazon EC2</a>
+                </td>
+                <td class="service-cell">
+                  <a href="https://azure.microsoft.com/products/virtual-machines/">
+                    Azure Virtual Machines
+                  </a>
+                </td>
+                <td class="service-cell">
+                  <a href="https://cloud.google.com/compute?hl=ja">Compute Engine</a>
+                </td>
                 <td class="note-cell">
                   汎用から GPU、SAP 認定インスタンスまで幅広いラインアップを提供。永続ディスクや
                   スナップショット、オートスケーリングの仕組みで柔軟にリソースを増減できます。
@@ -93,9 +101,21 @@
               </tr>
               <tr>
                 <th scope="row" class="category-cell">マネージド Kubernetes</th>
-                <td class="service-cell">Amazon Elastic Kubernetes Service (EKS)</td>
-                <td class="service-cell">Azure Kubernetes Service (AKS)</td>
-                <td class="service-cell">Google Kubernetes Engine (GKE)</td>
+                <td class="service-cell">
+                  <a href="https://aws.amazon.com/eks/">
+                    Amazon Elastic Kubernetes Service (EKS)
+                  </a>
+                </td>
+                <td class="service-cell">
+                  <a href="https://azure.microsoft.com/products/kubernetes-service/">
+                    Azure Kubernetes Service (AKS)
+                  </a>
+                </td>
+                <td class="service-cell">
+                  <a href="https://cloud.google.com/kubernetes-engine?hl=ja">
+                    Google Kubernetes Engine (GKE)
+                  </a>
+                </td>
                 <td class="note-cell">
                   コントロールプレーンの管理を各クラウドが担う Kubernetes サービス。オートスケール、
                   マルチゾーン構成、マネージドアドオンなどを活用することで運用負荷を抑えられます。
@@ -103,9 +123,17 @@
               </tr>
               <tr>
                 <th scope="row" class="category-cell">フルマネージド コンテナ実行</th>
-                <td class="service-cell">AWS App Runner</td>
-                <td class="service-cell">Azure Container Apps</td>
-                <td class="service-cell">Cloud Run</td>
+                <td class="service-cell">
+                  <a href="https://aws.amazon.com/apprunner/">AWS App Runner</a>
+                </td>
+                <td class="service-cell">
+                  <a href="https://azure.microsoft.com/products/container-apps/">
+                    Azure Container Apps
+                  </a>
+                </td>
+                <td class="service-cell">
+                  <a href="https://cloud.google.com/run?hl=ja">Cloud Run</a>
+                </td>
                 <td class="note-cell">
                   コンテナをソースコードや OCI イメージから即時にデプロイできる環境。トラフィック連
                   動のオートスケールやゼロスケール対応で、マイクロサービスや API バックエンドに最適
@@ -114,9 +142,17 @@
               </tr>
               <tr>
                 <th scope="row" class="category-cell">サーバーレス関数</th>
-                <td class="service-cell">AWS Lambda</td>
-                <td class="service-cell">Azure Functions</td>
-                <td class="service-cell">Cloud Functions (2nd gen)</td>
+                <td class="service-cell">
+                  <a href="https://aws.amazon.com/lambda/">AWS Lambda</a>
+                </td>
+                <td class="service-cell">
+                  <a href="https://azure.microsoft.com/products/functions/">Azure Functions</a>
+                </td>
+                <td class="service-cell">
+                  <a href="https://cloud.google.com/functions?hl=ja">
+                    Cloud Functions (2nd gen)
+                  </a>
+                </td>
                 <td class="note-cell">
                   イベント駆動の短時間処理に最適な関数サービス。トリガーの種類や最大実行時間、言語サ
                   ポートなどを比較してワークロードに適した構成を選択します。
@@ -124,9 +160,17 @@
               </tr>
               <tr>
                 <th scope="row" class="category-cell">オブジェクトストレージ</th>
-                <td class="service-cell">Amazon S3</td>
-                <td class="service-cell">Azure Blob Storage</td>
-                <td class="service-cell">Cloud Storage</td>
+                <td class="service-cell">
+                  <a href="https://aws.amazon.com/s3/">Amazon S3</a>
+                </td>
+                <td class="service-cell">
+                  <a href="https://azure.microsoft.com/products/storage/blobs/">
+                    Azure Blob Storage
+                  </a>
+                </td>
+                <td class="service-cell">
+                  <a href="https://cloud.google.com/storage?hl=ja">Cloud Storage</a>
+                </td>
                 <td class="note-cell">
                   静的コンテンツやバックアップ、データレイク基盤に利用される耐久性の高いストレージ。
                   ストレージクラスやライフサイクルポリシーを活用してコストとパフォーマンスを最適化。
@@ -134,9 +178,17 @@
               </tr>
               <tr>
                 <th scope="row" class="category-cell">リレーショナル DB (PaaS)</th>
-                <td class="service-cell">Amazon RDS</td>
-                <td class="service-cell">Azure SQL Database</td>
-                <td class="service-cell">Cloud SQL</td>
+                <td class="service-cell">
+                  <a href="https://aws.amazon.com/rds/">Amazon RDS</a>
+                </td>
+                <td class="service-cell">
+                  <a href="https://azure.microsoft.com/products/azure-sql/database/">
+                    Azure SQL Database
+                  </a>
+                </td>
+                <td class="service-cell">
+                  <a href="https://cloud.google.com/sql?hl=ja">Cloud SQL</a>
+                </td>
                 <td class="note-cell">
                   MySQL や PostgreSQL、SQL Server などのエンジンをマネージドで提供。自動バックアップや
                   フェイルオーバー、読み取りレプリカなどの機能で運用を簡素化します。
@@ -144,9 +196,17 @@
               </tr>
               <tr>
                 <th scope="row" class="category-cell">ドキュメント / キーバリュー DB</th>
-                <td class="service-cell">Amazon DynamoDB</td>
-                <td class="service-cell">Azure Cosmos DB</td>
-                <td class="service-cell">Cloud Firestore</td>
+                <td class="service-cell">
+                  <a href="https://aws.amazon.com/dynamodb/">Amazon DynamoDB</a>
+                </td>
+                <td class="service-cell">
+                  <a href="https://azure.microsoft.com/products/cosmos-db/">
+                    Azure Cosmos DB
+                  </a>
+                </td>
+                <td class="service-cell">
+                  <a href="https://cloud.google.com/firestore?hl=ja">Cloud Firestore</a>
+                </td>
                 <td class="note-cell">
                   スキーマレスでスケーラブルなデータベース。グローバル分散やマルチマスター構成、柔軟
                   なスループット課金などを備え、低レイテンシのアプリケーションに適しています。
@@ -154,9 +214,17 @@
               </tr>
               <tr>
                 <th scope="row" class="category-cell">データウェアハウス</th>
-                <td class="service-cell">Amazon Redshift</td>
-                <td class="service-cell">Azure Synapse Analytics (Dedicated SQL Pool)</td>
-                <td class="service-cell">BigQuery</td>
+                <td class="service-cell">
+                  <a href="https://aws.amazon.com/redshift/">Amazon Redshift</a>
+                </td>
+                <td class="service-cell">
+                  <a href="https://azure.microsoft.com/products/synapse-analytics/">
+                    Azure Synapse Analytics (Dedicated SQL Pool)
+                  </a>
+                </td>
+                <td class="service-cell">
+                  <a href="https://cloud.google.com/bigquery?hl=ja">BigQuery</a>
+                </td>
                 <td class="note-cell">
                   大規模データを分析するための高速クエリエンジン。サーバーレス実行やコンピュート/ス
                   トレージ分離、各種 BI 連携でデータ利活用を加速します。
@@ -164,9 +232,15 @@
               </tr>
               <tr>
                 <th scope="row" class="category-cell">メッセージング / イベント配信</th>
-                <td class="service-cell">Amazon SNS</td>
-                <td class="service-cell">Azure Event Grid</td>
-                <td class="service-cell">Pub/Sub</td>
+                <td class="service-cell">
+                  <a href="https://aws.amazon.com/sns/">Amazon SNS</a>
+                </td>
+                <td class="service-cell">
+                  <a href="https://azure.microsoft.com/products/event-grid/">Azure Event Grid</a>
+                </td>
+                <td class="service-cell">
+                  <a href="https://cloud.google.com/pubsub?hl=ja">Pub/Sub</a>
+                </td>
                 <td class="note-cell">
                   疎結合なイベント駆動アーキテクチャを構築するためのメッセージング基盤。Push/Pull 配
                   信やフィルタリング、他サービスとの統合のしやすさを比較することが重要です。
@@ -174,9 +248,15 @@
               </tr>
               <tr>
                 <th scope="row" class="category-cell">データ処理 / ETL</th>
-                <td class="service-cell">AWS Glue</td>
-                <td class="service-cell">Azure Data Factory</td>
-                <td class="service-cell">Dataflow</td>
+                <td class="service-cell">
+                  <a href="https://aws.amazon.com/glue/">AWS Glue</a>
+                </td>
+                <td class="service-cell">
+                  <a href="https://azure.microsoft.com/products/data-factory/">Azure Data Factory</a>
+                </td>
+                <td class="service-cell">
+                  <a href="https://cloud.google.com/dataflow?hl=ja">Dataflow</a>
+                </td>
                 <td class="note-cell">
                   サーバーレスでバッチ・ストリーミング処理を実現するデータ統合サービス。コネクタの種
                   類やスケーリング方式、コード/ノーコードの開発体験を比較します。
@@ -184,9 +264,17 @@
               </tr>
               <tr>
                 <th scope="row" class="category-cell">監視 / 可観測性</th>
-                <td class="service-cell">Amazon CloudWatch</td>
-                <td class="service-cell">Azure Monitor</td>
-                <td class="service-cell">Cloud Monitoring / Logging</td>
+                <td class="service-cell">
+                  <a href="https://aws.amazon.com/cloudwatch/">Amazon CloudWatch</a>
+                </td>
+                <td class="service-cell">
+                  <a href="https://azure.microsoft.com/products/monitor/">Azure Monitor</a>
+                </td>
+                <td class="service-cell">
+                  <a href="https://cloud.google.com/products/operations?hl=ja">
+                    Cloud Monitoring / Logging
+                  </a>
+                </td>
                 <td class="note-cell">
                   メトリクス、ログ、トレースを統合的に収集・可視化する監視基盤。自動アラートやダッシ
                   ュボード、外部ツールとの連携状況も選定のポイントです。


### PR DESCRIPTION
## Summary
- turn every service name in the comparison table into a link to the corresponding official product page
- point each AWS, Azure, and Google Cloud entry to its authoritative documentation or product site

## Testing
- not run (static content)


------
https://chatgpt.com/codex/tasks/task_e_68cd3a4a13708327888e135679abfa4c