### PR TITLE
Open comparison service links in new tabs

### DIFF
--- a/comparison.html
+++ b/comparison.html
@@ -84,15 +84,31 @@
               <tr>
                 <th scope="row" class="category-cell">仮想マシン (IaaS)</th>
                 <td class="service-cell">
-                  <a href="https://aws.amazon.com/ec2/">Amazon EC2</a>
+                  <a
+                    href="https://aws.amazon.com/ec2/"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    Amazon EC2
+                  </a>
                 </td>
                 <td class="service-cell">
-                  <a href="https://azure.microsoft.com/products/virtual-machines/">
+                  <a
+                    href="https://azure.microsoft.com/products/virtual-machines/"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
                     Azure Virtual Machines
                   </a>
                 </td>
                 <td class="service-cell">
-                  <a href="https://cloud.google.com/compute?hl=ja">Compute Engine</a>
+                  <a
+                    href="https://cloud.google.com/compute?hl=ja"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    Compute Engine
+                  </a>
                 </td>
                 <td class="note-cell">
                   汎用から GPU、SAP 認定インスタンスまで幅広いラインアップを提供。永続ディスクや
@@ -102,17 +118,29 @@
               <tr>
                 <th scope="row" class="category-cell">マネージド Kubernetes</th>
                 <td class="service-cell">
-                  <a href="https://aws.amazon.com/eks/">
+                  <a
+                    href="https://aws.amazon.com/eks/"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
                     Amazon Elastic Kubernetes Service (EKS)
                   </a>
                 </td>
                 <td class="service-cell">
-                  <a href="https://azure.microsoft.com/products/kubernetes-service/">
+                  <a
+                    href="https://azure.microsoft.com/products/kubernetes-service/"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
                     Azure Kubernetes Service (AKS)
                   </a>
                 </td>
                 <td class="service-cell">
-                  <a href="https://cloud.google.com/kubernetes-engine?hl=ja">
+                  <a
+                    href="https://cloud.google.com/kubernetes-engine?hl=ja"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
                     Google Kubernetes Engine (GKE)
                   </a>
                 </td>
@@ -124,15 +152,31 @@
               <tr>
                 <th scope="row" class="category-cell">フルマネージド コンテナ実行</th>
                 <td class="service-cell">
-                  <a href="https://aws.amazon.com/apprunner/">AWS App Runner</a>
+                  <a
+                    href="https://aws.amazon.com/apprunner/"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    AWS App Runner
+                  </a>
                 </td>
                 <td class="service-cell">
-                  <a href="https://azure.microsoft.com/products/container-apps/">
+                  <a
+                    href="https://azure.microsoft.com/products/container-apps/"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
                     Azure Container Apps
                   </a>
                 </td>
                 <td class="service-cell">
-                  <a href="https://cloud.google.com/run?hl=ja">Cloud Run</a>
+                  <a
+                    href="https://cloud.google.com/run?hl=ja"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    Cloud Run
+                  </a>
                 </td>
                 <td class="note-cell">
                   コンテナをソースコードや OCI イメージから即時にデプロイできる環境。トラフィック連
@@ -143,13 +187,29 @@
               <tr>
                 <th scope="row" class="category-cell">サーバーレス関数</th>
                 <td class="service-cell">
-                  <a href="https://aws.amazon.com/lambda/">AWS Lambda</a>
+                  <a
+                    href="https://aws.amazon.com/lambda/"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    AWS Lambda
+                  </a>
                 </td>
                 <td class="service-cell">
-                  <a href="https://azure.microsoft.com/products/functions/">Azure Functions</a>
+                  <a
+                    href="https://azure.microsoft.com/products/functions/"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    Azure Functions
+                  </a>
                 </td>
                 <td class="service-cell">
-                  <a href="https://cloud.google.com/functions?hl=ja">
+                  <a
+                    href="https://cloud.google.com/functions?hl=ja"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
                     Cloud Functions (2nd gen)
                   </a>
                 </td>
@@ -161,15 +221,31 @@
               <tr>
                 <th scope="row" class="category-cell">オブジェクトストレージ</th>
                 <td class="service-cell">
-                  <a href="https://aws.amazon.com/s3/">Amazon S3</a>
+                  <a
+                    href="https://aws.amazon.com/s3/"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    Amazon S3
+                  </a>
                 </td>
                 <td class="service-cell">
-                  <a href="https://azure.microsoft.com/products/storage/blobs/">
+                  <a
+                    href="https://azure.microsoft.com/products/storage/blobs/"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
                     Azure Blob Storage
                   </a>
                 </td>
                 <td class="service-cell">
-                  <a href="https://cloud.google.com/storage?hl=ja">Cloud Storage</a>
+                  <a
+                    href="https://cloud.google.com/storage?hl=ja"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    Cloud Storage
+                  </a>
                 </td>
                 <td class="note-cell">
                   静的コンテンツやバックアップ、データレイク基盤に利用される耐久性の高いストレージ。
@@ -179,15 +255,31 @@
               <tr>
                 <th scope="row" class="category-cell">リレーショナル DB (PaaS)</th>
                 <td class="service-cell">
-                  <a href="https://aws.amazon.com/rds/">Amazon RDS</a>
+                  <a
+                    href="https://aws.amazon.com/rds/"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    Amazon RDS
+                  </a>
                 </td>
                 <td class="service-cell">
-                  <a href="https://azure.microsoft.com/products/azure-sql/database/">
+                  <a
+                    href="https://azure.microsoft.com/products/azure-sql/database/"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
                     Azure SQL Database
                   </a>
                 </td>
                 <td class="service-cell">
-                  <a href="https://cloud.google.com/sql?hl=ja">Cloud SQL</a>
+                  <a
+                    href="https://cloud.google.com/sql?hl=ja"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    Cloud SQL
+                  </a>
                 </td>
                 <td class="note-cell">
                   MySQL や PostgreSQL、SQL Server などのエンジンをマネージドで提供。自動バックアップや
@@ -197,15 +289,31 @@
               <tr>
                 <th scope="row" class="category-cell">ドキュメント / キーバリュー DB</th>
                 <td class="service-cell">
-                  <a href="https://aws.amazon.com/dynamodb/">Amazon DynamoDB</a>
+                  <a
+                    href="https://aws.amazon.com/dynamodb/"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    Amazon DynamoDB
+                  </a>
                 </td>
                 <td class="service-cell">
-                  <a href="https://azure.microsoft.com/products/cosmos-db/">
+                  <a
+                    href="https://azure.microsoft.com/products/cosmos-db/"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
                     Azure Cosmos DB
                   </a>
                 </td>
                 <td class="service-cell">
-                  <a href="https://cloud.google.com/firestore?hl=ja">Cloud Firestore</a>
+                  <a
+                    href="https://cloud.google.com/firestore?hl=ja"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    Cloud Firestore
+                  </a>
                 </td>
                 <td class="note-cell">
                   スキーマレスでスケーラブルなデータベース。グローバル分散やマルチマスター構成、柔軟
@@ -215,15 +323,31 @@
               <tr>
                 <th scope="row" class="category-cell">データウェアハウス</th>
                 <td class="service-cell">
-                  <a href="https://aws.amazon.com/redshift/">Amazon Redshift</a>
+                  <a
+                    href="https://aws.amazon.com/redshift/"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    Amazon Redshift
+                  </a>
                 </td>
                 <td class="service-cell">
-                  <a href="https://azure.microsoft.com/products/synapse-analytics/">
+                  <a
+                    href="https://azure.microsoft.com/products/synapse-analytics/"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
                     Azure Synapse Analytics (Dedicated SQL Pool)
                   </a>
                 </td>
                 <td class="service-cell">
-                  <a href="https://cloud.google.com/bigquery?hl=ja">BigQuery</a>
+                  <a
+                    href="https://cloud.google.com/bigquery?hl=ja"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    BigQuery
+                  </a>
                 </td>
                 <td class="note-cell">
                   大規模データを分析するための高速クエリエンジン。サーバーレス実行やコンピュート/ス
@@ -233,13 +357,31 @@
               <tr>
                 <th scope="row" class="category-cell">メッセージング / イベント配信</th>
                 <td class="service-cell">
-                  <a href="https://aws.amazon.com/sns/">Amazon SNS</a>
+                  <a
+                    href="https://aws.amazon.com/sns/"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    Amazon SNS
+                  </a>
                 </td>
                 <td class="service-cell">
-                  <a href="https://azure.microsoft.com/products/event-grid/">Azure Event Grid</a>
+                  <a
+                    href="https://azure.microsoft.com/products/event-grid/"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    Azure Event Grid
+                  </a>
                 </td>
                 <td class="service-cell">
-                  <a href="https://cloud.google.com/pubsub?hl=ja">Pub/Sub</a>
+                  <a
+                    href="https://cloud.google.com/pubsub?hl=ja"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    Pub/Sub
+                  </a>
                 </td>
                 <td class="note-cell">
                   疎結合なイベント駆動アーキテクチャを構築するためのメッセージング基盤。Push/Pull 配
@@ -249,13 +391,31 @@
               <tr>
                 <th scope="row" class="category-cell">データ処理 / ETL</th>
                 <td class="service-cell">
-                  <a href="https://aws.amazon.com/glue/">AWS Glue</a>
+                  <a
+                    href="https://aws.amazon.com/glue/"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    AWS Glue
+                  </a>
                 </td>
                 <td class="service-cell">
-                  <a href="https://azure.microsoft.com/products/data-factory/">Azure Data Factory</a>
+                  <a
+                    href="https://azure.microsoft.com/products/data-factory/"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    Azure Data Factory
+                  </a>
                 </td>
                 <td class="service-cell">
-                  <a href="https://cloud.google.com/dataflow?hl=ja">Dataflow</a>
+                  <a
+                    href="https://cloud.google.com/dataflow?hl=ja"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    Dataflow
+                  </a>
                 </td>
                 <td class="note-cell">
                   サーバーレスでバッチ・ストリーミング処理を実現するデータ統合サービス。コネクタの種
@@ -265,13 +425,29 @@
               <tr>
                 <th scope="row" class="category-cell">監視 / 可観測性</th>
                 <td class="service-cell">
-                  <a href="https://aws.amazon.com/cloudwatch/">Amazon CloudWatch</a>
+                  <a
+                    href="https://aws.amazon.com/cloudwatch/"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    Amazon CloudWatch
+                  </a>
                 </td>
                 <td class="service-cell">
-                  <a href="https://azure.microsoft.com/products/monitor/">Azure Monitor</a>
+                  <a
+                    href="https://azure.microsoft.com/products/monitor/"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    Azure Monitor
+                  </a>
                 </td>
                 <td class="service-cell">
-                  <a href="https://cloud.google.com/products/operations?hl=ja">
+                  <a
+                    href="https://cloud.google.com/products/operations?hl=ja"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
                     Cloud Monitoring / Logging
                   </a>
                 </td>

--- a/styles.css
+++ b/styles.css
@@ -235,6 +235,52 @@ body {
   font-weight: 600;
 }
 
+.comparison-table .service-cell a {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 14px;
+  border-radius: 999px;
+  background: linear-gradient(
+    135deg,
+    rgba(var(--accent-rgb), 0.12) 0%,
+    rgba(var(--accent-rgb), 0.22) 100%
+  );
+  color: var(--accent-dark);
+  text-decoration: none;
+  transition: background var(--transition), color var(--transition),
+    box-shadow var(--transition), transform 0.25s ease;
+  box-shadow: 0 8px 20px rgba(var(--accent-rgb), 0.16);
+}
+
+.comparison-table .service-cell a::after {
+  content: '\2197';
+  font-size: 0.85em;
+  transition: transform 0.25s ease;
+}
+
+.comparison-table .service-cell a:hover,
+.comparison-table .service-cell a:focus {
+  background: linear-gradient(
+    135deg,
+    rgba(var(--accent-rgb), 0.18) 0%,
+    rgba(var(--accent-rgb), 0.32) 100%
+  );
+  color: var(--accent-dark);
+  transform: translateY(-2px);
+  box-shadow: 0 14px 28px rgba(var(--accent-rgb), 0.24);
+}
+
+.comparison-table .service-cell a:hover::after,
+.comparison-table .service-cell a:focus::after {
+  transform: translateY(-1px) translateX(2px);
+}
+
+.comparison-table .service-cell a:focus-visible {
+  outline: 3px solid rgba(var(--accent-rgb), 0.45);
+  outline-offset: 3px;
+}
+
 .comparison-table .note-cell {
   width: 31%;
   color: var(--text-muted);


### PR DESCRIPTION
## Summary
- update all external service links in the comparison table to open in a new tab with noopener security attributes
- refresh the comparison table link styling with gradient pills, subtle shadowing, and hover/focus feedback for a more polished look

## Testing
- not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68cd3b4226b483279c3eb686ddbcf26e