### PR TITLE
Tone down comparison link styling

### DIFF
--- a/aws.html
+++ b/aws.html
@@ -40,7 +40,7 @@
             <a class="nav-link" href="google-cloud.html">Google Cloud</a>
           </li>
           <li class="nav-item">
-            <a class="nav-link" href="comparison.html">サービス比較</a>
+            <a class="nav-link nav-link--subtle" href="comparison.html">サービス比較</a>
           </li>
         </ul>
       </nav>

--- a/azure.html
+++ b/azure.html
@@ -40,7 +40,7 @@
             <a class="nav-link" href="google-cloud.html">Google Cloud</a>
           </li>
           <li class="nav-item">
-            <a class="nav-link" href="comparison.html">サービス比較</a>
+            <a class="nav-link nav-link--subtle" href="comparison.html">サービス比較</a>
           </li>
         </ul>
       </nav>

--- a/comparison.html
+++ b/comparison.html
@@ -35,7 +35,7 @@
             <a class="nav-link" href="google-cloud.html">Google Cloud</a>
           </li>
           <li class="nav-item">
-            <a class="nav-link" href="comparison.html" aria-current="page">サービス比較</a>
+            <a class="nav-link nav-link--subtle" href="comparison.html" aria-current="page">サービス比較</a>
           </li>
         </ul>
       </nav>

--- a/google-cloud.html
+++ b/google-cloud.html
@@ -40,7 +40,7 @@
             <a class="nav-link" href="google-cloud.html" aria-current="page">Google Cloud</a>
           </li>
           <li class="nav-item">
-            <a class="nav-link" href="comparison.html">サービス比較</a>
+            <a class="nav-link nav-link--subtle" href="comparison.html">サービス比較</a>
           </li>
         </ul>
       </nav>

--- a/index.html
+++ b/index.html
@@ -63,7 +63,7 @@
             <a class="nav-link" href="google-cloud.html">Google Cloud</a>
           </li>
           <li class="nav-item">
-            <a class="nav-link" href="comparison.html">サービス比較</a>
+            <a class="nav-link nav-link--subtle" href="comparison.html">サービス比較</a>
           </li>
         </ul>
       </nav>

--- a/styles.css
+++ b/styles.css
@@ -135,6 +135,59 @@ body {
   box-shadow: 0 12px 30px rgba(var(--accent-rgb), 0.22);
 }
 
+.nav-link--subtle {
+  background: transparent;
+  color: var(--text-muted);
+  border: 1px solid rgba(var(--accent-rgb), 0.22);
+  border-radius: 12px;
+  padding: 8px 16px;
+  font-weight: 500;
+  letter-spacing: 0.02em;
+  box-shadow: none;
+}
+
+.nav-link--subtle::after {
+  content: '';
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  border-right: 1.5px solid currentColor;
+  border-bottom: 1.5px solid currentColor;
+  transform: translateY(-1px) rotate(-45deg);
+  transform-origin: center;
+  opacity: 0.6;
+  transition: transform 0.2s ease, opacity 0.2s ease;
+}
+
+.nav-link--subtle:hover,
+.nav-link--subtle:focus {
+  background: rgba(var(--accent-rgb), 0.08);
+  color: var(--accent-dark);
+  border-color: rgba(var(--accent-rgb), 0.35);
+}
+
+.nav-link--subtle:hover::after,
+.nav-link--subtle:focus::after {
+  opacity: 1;
+  transform: translate(1px, -1px) rotate(-45deg);
+}
+
+.nav-link--subtle:focus-visible {
+  outline: 3px solid rgba(var(--accent-rgb), 0.35);
+  outline-offset: 3px;
+}
+
+.nav-link--subtle[aria-current='page'] {
+  background: rgba(var(--accent-rgb), 0.12);
+  color: var(--accent-dark);
+  border-color: rgba(var(--accent-rgb), 0.35);
+  box-shadow: none;
+}
+
+.nav-link--subtle[aria-current='page']::after {
+  opacity: 1;
+}
+
 .page-main {
   flex: 1;
   width: min(1100px, 92vw);


### PR DESCRIPTION
## Summary
- add a muted `nav-link--subtle` variant so the comparison navigation entry feels less flashy while still decorated
- apply the new subtle styling to the comparison link across every page header

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68cd3de9986c8327a27f6e8c5a238ca6