### PR TITLE
Expand comparison table service listings

### DIFF
--- a/comparison.html
+++ b/comparison.html
@@ -84,31 +84,97 @@
               <tr>
                 <th scope="row" class="category-cell">仮想マシン (IaaS)</th>
                 <td class="service-cell">
-                  <a
-                    href="https://aws.amazon.com/ec2/"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    Amazon EC2
-                  </a>
+                  <ul class="service-list">
+                    <li>
+                      <a
+                        href="https://aws.amazon.com/ec2/"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        Amazon EC2
+                      </a>
+                    </li>
+                    <li>
+                      <a
+                        href="https://aws.amazon.com/lightsail/"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        AWS Lightsail
+                      </a>
+                    </li>
+                    <li>
+                      <a
+                        href="https://aws.amazon.com/outposts/"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        AWS Outposts
+                      </a>
+                    </li>
+                  </ul>
                 </td>
                 <td class="service-cell">
-                  <a
-                    href="https://azure.microsoft.com/products/virtual-machines/"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    Azure Virtual Machines
-                  </a>
+                  <ul class="service-list">
+                    <li>
+                      <a
+                        href="https://azure.microsoft.com/products/virtual-machines/"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        Azure Virtual Machines
+                      </a>
+                    </li>
+                    <li>
+                      <a
+                        href="https://azure.microsoft.com/products/virtual-machine-scale-sets/"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        Azure Virtual Machine Scale Sets
+                      </a>
+                    </li>
+                    <li>
+                      <a
+                        href="https://azure.microsoft.com/products/dedicated-host/"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        Azure Dedicated Host
+                      </a>
+                    </li>
+                  </ul>
                 </td>
                 <td class="service-cell">
-                  <a
-                    href="https://cloud.google.com/compute?hl=ja"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    Compute Engine
-                  </a>
+                  <ul class="service-list">
+                    <li>
+                      <a
+                        href="https://cloud.google.com/compute?hl=ja"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        Compute Engine
+                      </a>
+                    </li>
+                    <li>
+                      <a
+                        href="https://cloud.google.com/vmware-engine?hl=ja"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        Google Cloud VMware Engine
+                      </a>
+                    </li>
+                    <li>
+                      <a
+                        href="https://cloud.google.com/bare-metal?hl=ja"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        Bare Metal Solution
+                      </a>
+                    </li>
+                  </ul>
                 </td>
                 <td class="note-cell">
                   汎用から GPU、SAP 認定インスタンスまで幅広いラインアップを提供。永続ディスクや
@@ -118,31 +184,97 @@
               <tr>
                 <th scope="row" class="category-cell">マネージド Kubernetes</th>
                 <td class="service-cell">
-                  <a
-                    href="https://aws.amazon.com/eks/"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    Amazon Elastic Kubernetes Service (EKS)
-                  </a>
+                  <ul class="service-list">
+                    <li>
+                      <a
+                        href="https://aws.amazon.com/eks/"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        Amazon Elastic Kubernetes Service (EKS)
+                      </a>
+                    </li>
+                    <li>
+                      <a
+                        href="https://aws.amazon.com/eks/anywhere/"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        Amazon EKS Anywhere
+                      </a>
+                    </li>
+                    <li>
+                      <a
+                        href="https://aws.amazon.com/fargate/"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        AWS Fargate (EKS 対応)
+                      </a>
+                    </li>
+                  </ul>
                 </td>
                 <td class="service-cell">
-                  <a
-                    href="https://azure.microsoft.com/products/kubernetes-service/"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    Azure Kubernetes Service (AKS)
-                  </a>
+                  <ul class="service-list">
+                    <li>
+                      <a
+                        href="https://azure.microsoft.com/products/kubernetes-service/"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        Azure Kubernetes Service (AKS)
+                      </a>
+                    </li>
+                    <li>
+                      <a
+                        href="https://azure.microsoft.com/products/kubernetes-fleet/"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        Azure Kubernetes Fleet Manager
+                      </a>
+                    </li>
+                    <li>
+                      <a
+                        href="https://azure.microsoft.com/products/azure-arc/kubernetes/"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        Azure Arc-enabled Kubernetes
+                      </a>
+                    </li>
+                  </ul>
                 </td>
                 <td class="service-cell">
-                  <a
-                    href="https://cloud.google.com/kubernetes-engine?hl=ja"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    Google Kubernetes Engine (GKE)
-                  </a>
+                  <ul class="service-list">
+                    <li>
+                      <a
+                        href="https://cloud.google.com/kubernetes-engine?hl=ja"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        Google Kubernetes Engine (GKE)
+                      </a>
+                    </li>
+                    <li>
+                      <a
+                        href="https://cloud.google.com/kubernetes-engine/docs/concepts/autopilot-overview?hl=ja"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        GKE Autopilot
+                      </a>
+                    </li>
+                    <li>
+                      <a
+                        href="https://cloud.google.com/anthos?hl=ja"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        Anthos
+                      </a>
+                    </li>
+                  </ul>
                 </td>
                 <td class="note-cell">
                   コントロールプレーンの管理を各クラウドが担う Kubernetes サービス。オートスケール、
@@ -152,31 +284,97 @@
               <tr>
                 <th scope="row" class="category-cell">フルマネージド コンテナ実行</th>
                 <td class="service-cell">
-                  <a
-                    href="https://aws.amazon.com/apprunner/"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    AWS App Runner
-                  </a>
+                  <ul class="service-list">
+                    <li>
+                      <a
+                        href="https://aws.amazon.com/apprunner/"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        AWS App Runner
+                      </a>
+                    </li>
+                    <li>
+                      <a
+                        href="https://aws.amazon.com/fargate/"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        AWS Fargate
+                      </a>
+                    </li>
+                    <li>
+                      <a
+                        href="https://aws.amazon.com/lightsail/containers/"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        Amazon Lightsail Containers
+                      </a>
+                    </li>
+                  </ul>
                 </td>
                 <td class="service-cell">
-                  <a
-                    href="https://azure.microsoft.com/products/container-apps/"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    Azure Container Apps
-                  </a>
+                  <ul class="service-list">
+                    <li>
+                      <a
+                        href="https://azure.microsoft.com/products/container-apps/"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        Azure Container Apps
+                      </a>
+                    </li>
+                    <li>
+                      <a
+                        href="https://azure.microsoft.com/products/app-service/containers/"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        Azure App Service (コンテナ)
+                      </a>
+                    </li>
+                    <li>
+                      <a
+                        href="https://azure.microsoft.com/products/spring-apps/"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        Azure Spring Apps
+                      </a>
+                    </li>
+                  </ul>
                 </td>
                 <td class="service-cell">
-                  <a
-                    href="https://cloud.google.com/run?hl=ja"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    Cloud Run
-                  </a>
+                  <ul class="service-list">
+                    <li>
+                      <a
+                        href="https://cloud.google.com/run?hl=ja"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        Cloud Run
+                      </a>
+                    </li>
+                    <li>
+                      <a
+                        href="https://cloud.google.com/appengine?hl=ja"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        App Engine (Flexible)
+                      </a>
+                    </li>
+                    <li>
+                      <a
+                        href="https://cloud.google.com/run/docs/about-cloud-run-jobs?hl=ja"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        Cloud Run Jobs
+                      </a>
+                    </li>
+                  </ul>
                 </td>
                 <td class="note-cell">
                   コンテナをソースコードや OCI イメージから即時にデプロイできる環境。トラフィック連
@@ -187,31 +385,97 @@
               <tr>
                 <th scope="row" class="category-cell">サーバーレス関数</th>
                 <td class="service-cell">
-                  <a
-                    href="https://aws.amazon.com/lambda/"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    AWS Lambda
-                  </a>
+                  <ul class="service-list">
+                    <li>
+                      <a
+                        href="https://aws.amazon.com/lambda/"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        AWS Lambda
+                      </a>
+                    </li>
+                    <li>
+                      <a
+                        href="https://aws.amazon.com/lambda/edge/"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        AWS Lambda@Edge
+                      </a>
+                    </li>
+                    <li>
+                      <a
+                        href="https://aws.amazon.com/step-functions/"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        AWS Step Functions
+                      </a>
+                    </li>
+                  </ul>
                 </td>
                 <td class="service-cell">
-                  <a
-                    href="https://azure.microsoft.com/products/functions/"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    Azure Functions
-                  </a>
+                  <ul class="service-list">
+                    <li>
+                      <a
+                        href="https://azure.microsoft.com/products/functions/"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        Azure Functions
+                      </a>
+                    </li>
+                    <li>
+                      <a
+                        href="https://learn.microsoft.com/azure/azure-functions/durable/durable-functions-overview"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        Azure Durable Functions
+                      </a>
+                    </li>
+                    <li>
+                      <a
+                        href="https://azure.microsoft.com/products/logic-apps/"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        Azure Logic Apps
+                      </a>
+                    </li>
+                  </ul>
                 </td>
                 <td class="service-cell">
-                  <a
-                    href="https://cloud.google.com/functions?hl=ja"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    Cloud Functions (2nd gen)
-                  </a>
+                  <ul class="service-list">
+                    <li>
+                      <a
+                        href="https://cloud.google.com/functions?hl=ja"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        Cloud Functions (2nd gen)
+                      </a>
+                    </li>
+                    <li>
+                      <a
+                        href="https://firebase.google.com/docs/functions?hl=ja"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        Cloud Functions for Firebase
+                      </a>
+                    </li>
+                    <li>
+                      <a
+                        href="https://cloud.google.com/workflows?hl=ja"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        Workflows
+                      </a>
+                    </li>
+                  </ul>
                 </td>
                 <td class="note-cell">
                   イベント駆動の短時間処理に最適な関数サービス。トリガーの種類や最大実行時間、言語サ
@@ -221,31 +485,97 @@
               <tr>
                 <th scope="row" class="category-cell">オブジェクトストレージ</th>
                 <td class="service-cell">
-                  <a
-                    href="https://aws.amazon.com/s3/"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    Amazon S3
-                  </a>
+                  <ul class="service-list">
+                    <li>
+                      <a
+                        href="https://aws.amazon.com/s3/"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        Amazon S3
+                      </a>
+                    </li>
+                    <li>
+                      <a
+                        href="https://aws.amazon.com/s3/storage-classes/glacier/"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        Amazon S3 Glacier
+                      </a>
+                    </li>
+                    <li>
+                      <a
+                        href="https://aws.amazon.com/storagegateway/"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        AWS Storage Gateway (File Gateway)
+                      </a>
+                    </li>
+                  </ul>
                 </td>
                 <td class="service-cell">
-                  <a
-                    href="https://azure.microsoft.com/products/storage/blobs/"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    Azure Blob Storage
-                  </a>
+                  <ul class="service-list">
+                    <li>
+                      <a
+                        href="https://azure.microsoft.com/products/storage/blobs/"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        Azure Blob Storage
+                      </a>
+                    </li>
+                    <li>
+                      <a
+                        href="https://azure.microsoft.com/products/storage/data-lake/"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        Azure Data Lake Storage Gen2
+                      </a>
+                    </li>
+                    <li>
+                      <a
+                        href="https://azure.microsoft.com/products/storage/blobs/"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        Azure Blob Storage (アーカイブ層)
+                      </a>
+                    </li>
+                  </ul>
                 </td>
                 <td class="service-cell">
-                  <a
-                    href="https://cloud.google.com/storage?hl=ja"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    Cloud Storage
-                  </a>
+                  <ul class="service-list">
+                    <li>
+                      <a
+                        href="https://cloud.google.com/storage?hl=ja"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        Cloud Storage
+                      </a>
+                    </li>
+                    <li>
+                      <a
+                        href="https://cloud.google.com/storage/docs/storage-classes?hl=ja"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        Cloud Storage (Nearline / Coldline)
+                      </a>
+                    </li>
+                    <li>
+                      <a
+                        href="https://cloud.google.com/storage/docs/storage-classes?hl=ja"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        Cloud Storage (Archive)
+                      </a>
+                    </li>
+                  </ul>
                 </td>
                 <td class="note-cell">
                   静的コンテンツやバックアップ、データレイク基盤に利用される耐久性の高いストレージ。
@@ -255,31 +585,97 @@
               <tr>
                 <th scope="row" class="category-cell">リレーショナル DB (PaaS)</th>
                 <td class="service-cell">
-                  <a
-                    href="https://aws.amazon.com/rds/"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    Amazon RDS
-                  </a>
+                  <ul class="service-list">
+                    <li>
+                      <a
+                        href="https://aws.amazon.com/rds/"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        Amazon RDS
+                      </a>
+                    </li>
+                    <li>
+                      <a
+                        href="https://aws.amazon.com/rds/aurora/"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        Amazon Aurora
+                      </a>
+                    </li>
+                    <li>
+                      <a
+                        href="https://aws.amazon.com/rds/custom/"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        Amazon RDS Custom
+                      </a>
+                    </li>
+                  </ul>
                 </td>
                 <td class="service-cell">
-                  <a
-                    href="https://azure.microsoft.com/products/azure-sql/database/"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    Azure SQL Database
-                  </a>
+                  <ul class="service-list">
+                    <li>
+                      <a
+                        href="https://azure.microsoft.com/products/azure-sql/database/"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        Azure SQL Database
+                      </a>
+                    </li>
+                    <li>
+                      <a
+                        href="https://azure.microsoft.com/products/postgresql/"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        Azure Database for PostgreSQL
+                      </a>
+                    </li>
+                    <li>
+                      <a
+                        href="https://azure.microsoft.com/products/mysql/"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        Azure Database for MySQL
+                      </a>
+                    </li>
+                  </ul>
                 </td>
                 <td class="service-cell">
-                  <a
-                    href="https://cloud.google.com/sql?hl=ja"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    Cloud SQL
-                  </a>
+                  <ul class="service-list">
+                    <li>
+                      <a
+                        href="https://cloud.google.com/sql?hl=ja"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        Cloud SQL
+                      </a>
+                    </li>
+                    <li>
+                      <a
+                        href="https://cloud.google.com/alloydb?hl=ja"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        AlloyDB for PostgreSQL
+                      </a>
+                    </li>
+                    <li>
+                      <a
+                        href="https://cloud.google.com/spanner?hl=ja"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        Cloud Spanner
+                      </a>
+                    </li>
+                  </ul>
                 </td>
                 <td class="note-cell">
                   MySQL や PostgreSQL、SQL Server などのエンジンをマネージドで提供。自動バックアップや
@@ -289,31 +685,97 @@
               <tr>
                 <th scope="row" class="category-cell">ドキュメント / キーバリュー DB</th>
                 <td class="service-cell">
-                  <a
-                    href="https://aws.amazon.com/dynamodb/"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    Amazon DynamoDB
-                  </a>
+                  <ul class="service-list">
+                    <li>
+                      <a
+                        href="https://aws.amazon.com/dynamodb/"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        Amazon DynamoDB
+                      </a>
+                    </li>
+                    <li>
+                      <a
+                        href="https://aws.amazon.com/documentdb/"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        Amazon DocumentDB (MongoDB 互換)
+                      </a>
+                    </li>
+                    <li>
+                      <a
+                        href="https://aws.amazon.com/keyspaces/"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        Amazon Keyspaces (for Apache Cassandra)
+                      </a>
+                    </li>
+                  </ul>
                 </td>
                 <td class="service-cell">
-                  <a
-                    href="https://azure.microsoft.com/products/cosmos-db/"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    Azure Cosmos DB
-                  </a>
+                  <ul class="service-list">
+                    <li>
+                      <a
+                        href="https://azure.microsoft.com/products/cosmos-db/"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        Azure Cosmos DB
+                      </a>
+                    </li>
+                    <li>
+                      <a
+                        href="https://azure.microsoft.com/products/storage/tables/"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        Azure Table Storage
+                      </a>
+                    </li>
+                    <li>
+                      <a
+                        href="https://azure.microsoft.com/products/cache/"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        Azure Cache for Redis
+                      </a>
+                    </li>
+                  </ul>
                 </td>
                 <td class="service-cell">
-                  <a
-                    href="https://cloud.google.com/firestore?hl=ja"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    Cloud Firestore
-                  </a>
+                  <ul class="service-list">
+                    <li>
+                      <a
+                        href="https://cloud.google.com/firestore?hl=ja"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        Cloud Firestore
+                      </a>
+                    </li>
+                    <li>
+                      <a
+                        href="https://cloud.google.com/bigtable?hl=ja"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        Cloud Bigtable
+                      </a>
+                    </li>
+                    <li>
+                      <a
+                        href="https://firebase.google.com/products/realtime-database?hl=ja"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        Firebase Realtime Database
+                      </a>
+                    </li>
+                  </ul>
                 </td>
                 <td class="note-cell">
                   スキーマレスでスケーラブルなデータベース。グローバル分散やマルチマスター構成、柔軟
@@ -323,31 +785,97 @@
               <tr>
                 <th scope="row" class="category-cell">データウェアハウス</th>
                 <td class="service-cell">
-                  <a
-                    href="https://aws.amazon.com/redshift/"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    Amazon Redshift
-                  </a>
+                  <ul class="service-list">
+                    <li>
+                      <a
+                        href="https://aws.amazon.com/redshift/"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        Amazon Redshift
+                      </a>
+                    </li>
+                    <li>
+                      <a
+                        href="https://aws.amazon.com/redshift/serverless/"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        Amazon Redshift Serverless
+                      </a>
+                    </li>
+                    <li>
+                      <a
+                        href="https://aws.amazon.com/athena/"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        Amazon Athena
+                      </a>
+                    </li>
+                  </ul>
                 </td>
                 <td class="service-cell">
-                  <a
-                    href="https://azure.microsoft.com/products/synapse-analytics/"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    Azure Synapse Analytics (Dedicated SQL Pool)
-                  </a>
+                  <ul class="service-list">
+                    <li>
+                      <a
+                        href="https://azure.microsoft.com/products/synapse-analytics/"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        Azure Synapse Analytics (Dedicated SQL Pool)
+                      </a>
+                    </li>
+                    <li>
+                      <a
+                        href="https://learn.microsoft.com/azure/synapse-analytics/sql/on-demand-workspace-overview"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        Azure Synapse Analytics (Serverless SQL)
+                      </a>
+                    </li>
+                    <li>
+                      <a
+                        href="https://learn.microsoft.com/azure/synapse-analytics/data-explorer/data-explorer-overview"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        Azure Synapse Data Explorer
+                      </a>
+                    </li>
+                  </ul>
                 </td>
                 <td class="service-cell">
-                  <a
-                    href="https://cloud.google.com/bigquery?hl=ja"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    BigQuery
-                  </a>
+                  <ul class="service-list">
+                    <li>
+                      <a
+                        href="https://cloud.google.com/bigquery?hl=ja"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        BigQuery
+                      </a>
+                    </li>
+                    <li>
+                      <a
+                        href="https://cloud.google.com/bigquery-omni?hl=ja"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        BigQuery Omni
+                      </a>
+                    </li>
+                    <li>
+                      <a
+                        href="https://cloud.google.com/bi-engine?hl=ja"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        BigQuery BI Engine
+                      </a>
+                    </li>
+                  </ul>
                 </td>
                 <td class="note-cell">
                   大規模データを分析するための高速クエリエンジン。サーバーレス実行やコンピュート/ス
@@ -357,31 +885,97 @@
               <tr>
                 <th scope="row" class="category-cell">メッセージング / イベント配信</th>
                 <td class="service-cell">
-                  <a
-                    href="https://aws.amazon.com/sns/"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    Amazon SNS
-                  </a>
+                  <ul class="service-list">
+                    <li>
+                      <a
+                        href="https://aws.amazon.com/sns/"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        Amazon SNS
+                      </a>
+                    </li>
+                    <li>
+                      <a
+                        href="https://aws.amazon.com/sqs/"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        Amazon SQS
+                      </a>
+                    </li>
+                    <li>
+                      <a
+                        href="https://aws.amazon.com/eventbridge/"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        Amazon EventBridge
+                      </a>
+                    </li>
+                  </ul>
                 </td>
                 <td class="service-cell">
-                  <a
-                    href="https://azure.microsoft.com/products/event-grid/"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    Azure Event Grid
-                  </a>
+                  <ul class="service-list">
+                    <li>
+                      <a
+                        href="https://azure.microsoft.com/products/event-grid/"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        Azure Event Grid
+                      </a>
+                    </li>
+                    <li>
+                      <a
+                        href="https://azure.microsoft.com/products/service-bus/"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        Azure Service Bus
+                      </a>
+                    </li>
+                    <li>
+                      <a
+                        href="https://azure.microsoft.com/products/event-hubs/"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        Azure Event Hubs
+                      </a>
+                    </li>
+                  </ul>
                 </td>
                 <td class="service-cell">
-                  <a
-                    href="https://cloud.google.com/pubsub?hl=ja"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    Pub/Sub
-                  </a>
+                  <ul class="service-list">
+                    <li>
+                      <a
+                        href="https://cloud.google.com/pubsub?hl=ja"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        Pub/Sub
+                      </a>
+                    </li>
+                    <li>
+                      <a
+                        href="https://cloud.google.com/pubsub/lite?hl=ja"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        Pub/Sub Lite
+                      </a>
+                    </li>
+                    <li>
+                      <a
+                        href="https://cloud.google.com/eventarc?hl=ja"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        Eventarc
+                      </a>
+                    </li>
+                  </ul>
                 </td>
                 <td class="note-cell">
                   疎結合なイベント駆動アーキテクチャを構築するためのメッセージング基盤。Push/Pull 配
@@ -391,31 +985,97 @@
               <tr>
                 <th scope="row" class="category-cell">データ処理 / ETL</th>
                 <td class="service-cell">
-                  <a
-                    href="https://aws.amazon.com/glue/"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    AWS Glue
-                  </a>
+                  <ul class="service-list">
+                    <li>
+                      <a
+                        href="https://aws.amazon.com/glue/"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        AWS Glue
+                      </a>
+                    </li>
+                    <li>
+                      <a
+                        href="https://aws.amazon.com/glue/features/databrew/"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        AWS Glue DataBrew
+                      </a>
+                    </li>
+                    <li>
+                      <a
+                        href="https://aws.amazon.com/emr/"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        Amazon EMR
+                      </a>
+                    </li>
+                  </ul>
                 </td>
                 <td class="service-cell">
-                  <a
-                    href="https://azure.microsoft.com/products/data-factory/"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    Azure Data Factory
-                  </a>
+                  <ul class="service-list">
+                    <li>
+                      <a
+                        href="https://azure.microsoft.com/products/data-factory/"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        Azure Data Factory
+                      </a>
+                    </li>
+                    <li>
+                      <a
+                        href="https://learn.microsoft.com/azure/synapse-analytics/data-integration/what-is-synapse-pipelines"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        Azure Synapse Pipelines
+                      </a>
+                    </li>
+                    <li>
+                      <a
+                        href="https://azure.microsoft.com/products/databricks/"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        Azure Databricks
+                      </a>
+                    </li>
+                  </ul>
                 </td>
                 <td class="service-cell">
-                  <a
-                    href="https://cloud.google.com/dataflow?hl=ja"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    Dataflow
-                  </a>
+                  <ul class="service-list">
+                    <li>
+                      <a
+                        href="https://cloud.google.com/dataflow?hl=ja"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        Dataflow
+                      </a>
+                    </li>
+                    <li>
+                      <a
+                        href="https://cloud.google.com/dataproc?hl=ja"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        Dataproc
+                      </a>
+                    </li>
+                    <li>
+                      <a
+                        href="https://cloud.google.com/dataform?hl=ja"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        Dataform
+                      </a>
+                    </li>
+                  </ul>
                 </td>
                 <td class="note-cell">
                   サーバーレスでバッチ・ストリーミング処理を実現するデータ統合サービス。コネクタの種
@@ -425,31 +1085,97 @@
               <tr>
                 <th scope="row" class="category-cell">監視 / 可観測性</th>
                 <td class="service-cell">
-                  <a
-                    href="https://aws.amazon.com/cloudwatch/"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    Amazon CloudWatch
-                  </a>
+                  <ul class="service-list">
+                    <li>
+                      <a
+                        href="https://aws.amazon.com/cloudwatch/"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        Amazon CloudWatch
+                      </a>
+                    </li>
+                    <li>
+                      <a
+                        href="https://aws.amazon.com/xray/"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        AWS X-Ray
+                      </a>
+                    </li>
+                    <li>
+                      <a
+                        href="https://aws.amazon.com/cloudtrail/"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        AWS CloudTrail
+                      </a>
+                    </li>
+                  </ul>
                 </td>
                 <td class="service-cell">
-                  <a
-                    href="https://azure.microsoft.com/products/monitor/"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    Azure Monitor
-                  </a>
+                  <ul class="service-list">
+                    <li>
+                      <a
+                        href="https://azure.microsoft.com/products/monitor/"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        Azure Monitor
+                      </a>
+                    </li>
+                    <li>
+                      <a
+                        href="https://learn.microsoft.com/azure/azure-monitor/app/app-insights-overview"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        Azure Application Insights
+                      </a>
+                    </li>
+                    <li>
+                      <a
+                        href="https://learn.microsoft.com/azure/azure-monitor/logs/log-analytics-overview"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        Azure Log Analytics
+                      </a>
+                    </li>
+                  </ul>
                 </td>
                 <td class="service-cell">
-                  <a
-                    href="https://cloud.google.com/products/operations?hl=ja"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    Cloud Monitoring / Logging
-                  </a>
+                  <ul class="service-list">
+                    <li>
+                      <a
+                        href="https://cloud.google.com/products/operations?hl=ja"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        Cloud Monitoring / Logging
+                      </a>
+                    </li>
+                    <li>
+                      <a
+                        href="https://cloud.google.com/trace?hl=ja"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        Cloud Trace
+                      </a>
+                    </li>
+                    <li>
+                      <a
+                        href="https://cloud.google.com/profiler?hl=ja"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        Cloud Profiler
+                      </a>
+                    </li>
+                  </ul>
                 </td>
                 <td class="note-cell">
                   メトリクス、ログ、トレースを統合的に収集・可視化する監視基盤。自動アラートやダッシ

--- a/styles.css
+++ b/styles.css
@@ -235,9 +235,25 @@ body {
   font-weight: 600;
 }
 
+.comparison-table .service-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.comparison-table .service-list li {
+  display: flex;
+  align-items: flex-start;
+}
+
 .comparison-table .service-cell a {
   display: inline-flex;
   align-items: center;
+  justify-content: flex-start;
+  flex-wrap: wrap;
   gap: 6px;
   padding: 4px 12px;
   border-radius: 12px;


### PR DESCRIPTION
## Summary
- expand each provider column in the comparison table to list multiple related services per category
- adjust comparison table styling so the stacked service links display cleanly

## Testing
- not run (static HTML/CSS updates)


------
https://chatgpt.com/codex/tasks/task_e_68cd41379db88327995a9d10b186adf9