### PR TITLE
Make comparison table headers sticky

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -183,7 +183,7 @@ body {
   background: var(--card-bg);
   box-shadow: var(--shadow-sm);
   border: 1px solid rgba(var(--accent-rgb), 0.12);
-  overflow-x: auto;
+  overflow: auto;
 }
 
 .comparison-table {
@@ -210,12 +210,28 @@ body {
 }
 
 .comparison-table thead th {
+  position: sticky;
+  top: 0;
+  z-index: 3;
   background: rgba(var(--accent-rgb), 0.12);
   color: var(--accent-dark);
   font-weight: 700;
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  box-shadow: 0 2px 0 rgba(var(--accent-rgb), 0.14);
+}
+
+.comparison-table thead th:first-child {
+  left: 0;
+  z-index: 5;
+  box-shadow: 2px 0 0 rgba(var(--accent-rgb), 0.14), 0 2px 0 rgba(var(--accent-rgb), 0.14);
 }
 
 .comparison-table tbody tr:nth-child(even) {
+  background: rgba(var(--accent-rgb), 0.04);
+}
+
+.comparison-table tbody tr:nth-child(even) .category-cell {
   background: rgba(var(--accent-rgb), 0.04);
 }
 
@@ -228,6 +244,11 @@ body {
   width: 18%;
   font-weight: 700;
   color: var(--accent-dark);
+  position: sticky;
+  left: 0;
+  z-index: 2;
+  background: var(--card-bg);
+  box-shadow: 2px 0 0 rgba(var(--accent-rgb), 0.12);
 }
 
 .comparison-table .service-cell {


### PR DESCRIPTION
## Summary
- keep the comparison table header row fixed as users scroll the data
- keep the first column fixed with matching zebra-striping for readability
- allow the table wrapper to scroll in both directions so the locked areas work consistently

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68cde37cb20883279ec0de7d40b14191