### PR TITLE
Fix sticky header on comparison table

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -183,7 +183,7 @@ body {
   background: var(--card-bg);
   box-shadow: var(--shadow-sm);
   border: 1px solid rgba(var(--accent-rgb), 0.12);
-  overflow: auto;
+  overflow-x: auto;
 }
 
 .comparison-table {


### PR DESCRIPTION
## Summary
- adjust the comparison table wrapper to only scroll horizontally so the header row can stay sticky while the page scrolls

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68cde548354883278ecd57550dc561b0