### PR TITLE
Make hero title link to home page

### DIFF
--- a/aws.html
+++ b/aws.html
@@ -25,7 +25,9 @@
     data-provider-key="aws"
   >
     <header class="page-header">
-      <h1 class="headline">Amazon Web Services サービスマップ</h1>
+      <h1 class="headline">
+        <a class="headline__link" href="index.html">Amazon Web Services サービスマップ</a>
+      </h1>
       <p class="tagline">
         AWS の代表的なサービスを領域ごとに俯瞰し、選定や比較の起点となる情報を集約し
         ました。

--- a/azure.html
+++ b/azure.html
@@ -25,7 +25,9 @@
     data-provider-key="azure"
   >
     <header class="page-header">
-      <h1 class="headline">Microsoft Azure サービスマップ</h1>
+      <h1 class="headline">
+        <a class="headline__link" href="index.html">Microsoft Azure サービスマップ</a>
+      </h1>
       <p class="tagline">
         Microsoft Azure が提供する主要サービスをカテゴリごとにまとめ、特徴と活用イメージ
         を素早く確認できます。

--- a/comparison.html
+++ b/comparison.html
@@ -19,7 +19,9 @@
   </head>
   <body class="theme-compare">
     <header class="page-header">
-      <h1 class="headline">主要クラウドサービス比較表</h1>
+      <h1 class="headline">
+        <a class="headline__link" href="index.html">主要クラウドサービス比較表</a>
+      </h1>
       <p class="tagline">
         Amazon Web Services、Microsoft Azure、Google Cloud で提供されている代表的なサービス
         の対応関係をカテゴリ別に整理しました。マルチクラウド戦略の検討や移行時の置き換え先の

--- a/google-cloud.html
+++ b/google-cloud.html
@@ -25,7 +25,9 @@
     data-provider-key="google-cloud"
   >
     <header class="page-header">
-      <h1 class="headline">Google Cloud サービスマップ</h1>
+      <h1 class="headline">
+        <a class="headline__link" href="index.html">Google Cloud サービスマップ</a>
+      </h1>
       <p class="tagline">
         Google Cloud が提供するサービスをカテゴリごとに整理し、概要と特徴をひと目で
         確認できます。

--- a/index.html
+++ b/index.html
@@ -20,7 +20,9 @@
   <body class="theme-home">
     <header class="page-header home-header">
       <p class="hero-label">CLOUD LANDSCAPE GUIDE</p>
-      <h1 class="hero-title">クラウドサービス マップ</h1>
+      <h1 class="hero-title">
+        <a class="hero-title__link" href="index.html">クラウドサービス マップ</a>
+      </h1>
       <p class="hero-lead">
         Amazon Web Services、Microsoft Azure、Google Cloud を横断して、主要サービスの概要と
         強みを俯瞰できるリソースです。マルチクラウドの比較検討や学習の入口としてご活用ください。

--- a/styles.css
+++ b/styles.css
@@ -658,6 +658,11 @@ body {
   letter-spacing: 0.05em;
 }
 
+.hero-title__link {
+  color: inherit;
+  text-decoration: none;
+}
+
 .hero-lead {
   margin: 20px auto 0;
   max-width: 760px;

--- a/styles.css
+++ b/styles.css
@@ -663,6 +663,15 @@ body {
   text-decoration: none;
 }
 
+.hero-title__link:visited {
+  color: inherit;
+}
+
+.hero-title__link:hover,
+.hero-title__link:focus-visible {
+  text-decoration: none;
+}
+
 .hero-lead {
   margin: 20px auto 0;
   max-width: 760px;

--- a/styles.css
+++ b/styles.css
@@ -81,6 +81,20 @@ body {
   letter-spacing: 0.04em;
 }
 
+.headline__link {
+  color: inherit;
+  text-decoration: none;
+}
+
+.headline__link:visited {
+  color: inherit;
+}
+
+.headline__link:hover,
+.headline__link:focus-visible {
+  text-decoration: none;
+}
+
 .tagline {
   margin: 16px auto 0;
   max-width: 720px;


### PR DESCRIPTION
## Summary
- add a homepage link to the hero title on the landing page
- keep existing appearance by inheriting color and removing text decoration

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6933c9d64fc4832799a5f3ffcdf2ddb5)